### PR TITLE
Feature/fetch missions

### DIFF
--- a/src/components/MissionsList.jsx
+++ b/src/components/MissionsList.jsx
@@ -13,7 +13,10 @@ function MissionsList() {
 
   return (
     <section>
-      missions
+      {missions.missionsArr.map((mission)=>(
+          <h3 key={mission.id}>{mission.name}</h3>
+        )
+      )}
     </section>
   )
 }

--- a/src/components/MissionsList.jsx
+++ b/src/components/MissionsList.jsx
@@ -1,6 +1,20 @@
+import { useSelector, useDispatch } from 'react-redux';
+import { useEffect } from 'react';
+import { getMissions } from '../redux/missions/missionsSlice';
+
 function MissionsList() {
+  const missions = useSelector((store) => store.missions);
+
+  const dispatch = useDispatch();
+
+  useEffect(() => {
+    dispatch(getMissions());
+  }, [dispatch]);
+
   return (
-    <div>MissionsList</div>
+    <section>
+      missions
+    </section>
   )
 }
 

--- a/src/redux/missions/missionsSlice.js
+++ b/src/redux/missions/missionsSlice.js
@@ -1,0 +1,50 @@
+import { createSlice, createAsyncThunk } from '@reduxjs/toolkit';
+import axios from 'axios';
+
+const API_URL = 'https://api.spacexdata.com/v3/missions';
+
+export const getMissions = createAsyncThunk('missions/getMissions', async () => {
+  try {
+    const response = await axios.get(API_URL);
+    return response.data;
+  } catch (error) {
+    return error.message;
+  }
+});
+
+const initialState = {
+  missionsArr: [],
+  status: 'idle',
+  error: null,
+};
+
+const missionsSlice = createSlice({
+  name: 'missions',
+  initialState,
+  reducers: {},
+  extraReducers: (builder) => {
+    builder
+      .addCase(getMissions.fulfilled, (state, action) => {
+        state.status = 'fulfilled';
+        const newArr = [];
+        action.payload.forEach(mission => {
+          let newMission = {
+            id: mission.mission_id,
+            name: mission.mission_name,
+            description: mission.description
+          }
+          newArr.push(newMission)
+        });
+        state.missionsArr = newArr
+      })
+      .addCase(getMissions.pending, (state) => {
+        state.status = 'Loading';
+      })
+      .addCase(getMissions.rejected, (state, action) => {
+        state.status = 'rejected';
+        state.error = action.error.message
+      })
+  },
+});
+
+export default missionsSlice.reducer;

--- a/src/redux/store.js
+++ b/src/redux/store.js
@@ -1,7 +1,8 @@
 import { configureStore } from '@reduxjs/toolkit';
+import missionsReducer from './missions/missionsSlice';
 
 const store = configureStore({
-  reducer: {},
+  reducer: {missions: missionsReducer,},
 });
 
 export default store;


### PR DESCRIPTION
Hi @Luiscarlosvd! 
In this branch I've worked on the fetching missions feature and achieve the following:
- Add the getMissions middleware to fetch the api.
- Add reducers to update the state on pending, rejected and fulfilled status.
- Add useEffect on the MissionsList component to dispatch the fetching when the component render.
- get the missions list from the state using `useSelector()` and display the missions titles.
- linters are passing and everything is working as expected.